### PR TITLE
Direct schedule/conflict lookup & service fixes

### DIFF
--- a/src/components/ChatBot.js
+++ b/src/components/ChatBot.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { sendMessage as sendLangflowMessage } from '../lib/langflowService';
+import { getToken } from '../lib/jwt';
+import { apiUrl } from '../constants/apiConstants';
 
 const ChatBot = () => {
   const defaultPanelWidth = 280;
@@ -12,6 +14,14 @@ const ChatBot = () => {
   const resizingRef = useRef(false);
   const resizeStartXRef = useRef(0);
   const resizeStartWidthRef = useRef(defaultPanelWidth);
+
+  const scheduleApiBases = [
+    process.env.REACT_APP_API_URL,
+    process.env.REACT_APP_API_BASE,
+    apiUrl,
+    'http://3.143.57.120:3000',
+    'http://localhost:3000',
+  ].filter(Boolean);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -49,6 +59,223 @@ const ChatBot = () => {
     document.body.style.userSelect = 'none';
   };
 
+  const appendBotMessage = (type, text) => {
+    setMessages((prev) => {
+      const last = prev[prev.length - 1];
+      if (last && last.type === type && String(last.text || '').trim() === String(text || '').trim()) {
+        return prev;
+      }
+      return [...prev, { type, text }];
+    });
+  };
+
+  const isScheduleListRequest = (text) => {
+    const normalized = text.toLowerCase();
+    return (
+      normalized.includes('show all schedules') ||
+      normalized.includes('all schedules') ||
+      normalized.includes('show schedules') ||
+      normalized.includes('view schedules') ||
+      normalized.includes('schedule') ||
+      normalized.includes('schedules') ||
+      normalized.includes('conflict') ||
+      normalized.includes('conflicts') ||
+      normalized.includes('availability') ||
+      normalized.includes('calendar') ||
+      normalized === 'schedules' ||
+      normalized === 'schedule'
+    );
+  };
+
+  const isConflictRequest = (text) => {
+    const normalized = text.toLowerCase();
+    return (
+      normalized.includes('conflict') ||
+      normalized.includes('conflicts') ||
+      normalized.includes('overlap') ||
+      normalized.includes('double book') ||
+      normalized.includes('double-book') ||
+      normalized.includes('scheduling issue')
+    );
+  };
+
+  const isAuthFollowUpForScheduleRequest = (text) => {
+    const normalized = text.toLowerCase();
+    const authWords = ['authorization', 'unauthorized', 'login', 'log in', 'logged in', 'token', 'session'];
+    return authWords.some((word) => normalized.includes(word));
+  };
+
+  const getLastUserMessage = () => {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      if (messages[index]?.type === 'user') {
+        return String(messages[index].text || '');
+      }
+    }
+    return '';
+  };
+
+  const shouldUseDirectScheduleLookup = (text) => {
+    if (isScheduleListRequest(text)) {
+      return true;
+    }
+
+    if (isAuthFollowUpForScheduleRequest(text)) {
+      return isScheduleListRequest(getLastUserMessage());
+    }
+
+    return false;
+  };
+
+  const shouldUseDirectConflictLookup = (text) => {
+    if (isConflictRequest(text)) {
+      return true;
+    }
+
+    if (isAuthFollowUpForScheduleRequest(text)) {
+      return isConflictRequest(getLastUserMessage());
+    }
+
+    return false;
+  };
+
+  const formatScheduleEntry = (item, index) => {
+    const title = item.event_title || item.title || item.subject || 'Untitled';
+    const teacherName = item.first_name && item.last_name
+      ? `${item.first_name} ${item.last_name}`
+      : item.teacher || item.teacher_name || (item.user_id ? `Teacher #${item.user_id}` : 'Teacher unknown');
+    const room = item.room || item.room_number || 'TBA';
+    const grade = item.grade || 'N/A';
+    const start = item.start_time || item.start || '';
+    const end = item.end_time || item.end || '';
+    const timeRange = start && end ? `${start} - ${end}` : 'Time unavailable';
+
+    return `${index + 1}. ${title}\n   Teacher: ${teacherName}\n   Room: ${room}\n   Grade: ${grade}\n   Time: ${timeRange}`;
+  };
+
+  const fetchSchedulesData = async () => {
+    const token = getToken();
+    if (!token) {
+      return { ok: false, error: 'Auth token missing. Please log in again.' };
+    }
+
+    for (const baseUrl of scheduleApiBases) {
+      try {
+        const response = await fetch(`${baseUrl}/api/schedules`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        if (!response.ok) {
+          continue;
+        }
+
+        const data = await response.json();
+        return {
+          ok: true,
+          schedules: Array.isArray(data) ? data : [],
+        };
+      } catch (error) {
+        continue;
+      }
+    }
+
+    return { ok: false, error: 'Unable to load schedules right now. Please try again.' };
+  };
+
+  const fetchAllSchedules = async () => {
+    const result = await fetchSchedulesData();
+    if (!result.ok) {
+      return result;
+    }
+
+    const lines = result.schedules.map((item, index) => formatScheduleEntry(item, index));
+    return {
+      ok: true,
+      text: lines.length
+        ? `I found ${lines.length} schedule${lines.length === 1 ? '' : 's'}:\n\n${lines.join('\n\n')}`
+        : 'No schedules were found.',
+    };
+  };
+
+  const detectConflicts = (rawSchedules) => {
+    const normalized = rawSchedules
+      .map((item) => {
+        const start = new Date(item.start_time || item.start);
+        const end = new Date(item.end_time || item.end);
+        if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+          return null;
+        }
+
+        const recurringDay = item.recurring_day !== undefined && item.recurring_day !== null
+          ? Number(item.recurring_day)
+          : null;
+
+        return {
+          id: item.idcalendar || item.id,
+          title: item.event_title || item.title || item.subject || 'Untitled',
+          teacherId: item.user_id || item.teacher_id || item.teacherId || null,
+          teacherName: item.first_name && item.last_name
+            ? `${item.first_name} ${item.last_name}`
+            : item.teacher || item.teacher_name || 'Unknown teacher',
+          room: String(item.room || item.room_number || '').trim(),
+          start,
+          end,
+          dayKey: recurringDay !== null && !Number.isNaN(recurringDay) ? recurringDay : start.getDay(),
+        };
+      })
+      .filter(Boolean);
+
+    const overlaps = (a, b) => a.start < b.end && b.start < a.end;
+    const conflicts = [];
+
+    for (let i = 0; i < normalized.length; i += 1) {
+      for (let j = i + 1; j < normalized.length; j += 1) {
+        const first = normalized[i];
+        const second = normalized[j];
+        if (first.dayKey !== second.dayKey) continue;
+        if (!overlaps(first, second)) continue;
+
+        if (first.teacherId && second.teacherId && String(first.teacherId) === String(second.teacherId)) {
+          conflicts.push({
+            type: 'Teacher',
+            subject: first.teacherName,
+            a: first,
+            b: second,
+          });
+        }
+
+        if (first.room && second.room && first.room.toLowerCase() === second.room.toLowerCase()) {
+          conflicts.push({
+            type: 'Room',
+            subject: first.room,
+            a: first,
+            b: second,
+          });
+        }
+      }
+    }
+
+    return conflicts;
+  };
+
+  const formatConflictResponse = (conflicts) => {
+    if (!conflicts.length) {
+      return 'I checked all schedules and found no conflicts.';
+    }
+
+    const preview = conflicts.slice(0, 20).map((conflict, index) => {
+      const aStart = conflict.a.start.toLocaleString();
+      const aEnd = conflict.a.end.toLocaleString();
+      const bStart = conflict.b.start.toLocaleString();
+      const bEnd = conflict.b.end.toLocaleString();
+      return `${index + 1}. ${conflict.type} conflict (${conflict.subject})\n   A: ${conflict.a.title} (${aStart} - ${aEnd})\n   B: ${conflict.b.title} (${bStart} - ${bEnd})`;
+    });
+
+    const suffix = conflicts.length > 20 ? `\n\nShowing first 20 of ${conflicts.length} conflicts.` : '';
+    return `I found ${conflicts.length} scheduling conflict${conflicts.length === 1 ? '' : 's'}:\n\n${preview.join('\n\n')}${suffix}`;
+  };
+
   const sendMessage = async () => {
     if (!inputValue.trim() || loading) return;
 
@@ -59,18 +286,55 @@ const ChatBot = () => {
     setLoading(true);
 
     try {
+      if (shouldUseDirectConflictLookup(userMessage)) {
+        const result = await fetchSchedulesData();
+        if (!result.ok) {
+          appendBotMessage('error', result.error || 'Unable to check conflicts right now.');
+          return;
+        }
+
+        const conflicts = detectConflicts(result.schedules);
+        appendBotMessage('bot', formatConflictResponse(conflicts));
+        return;
+      }
+
+      if (shouldUseDirectScheduleLookup(userMessage)) {
+        const scheduleResult = await fetchAllSchedules();
+        if (!scheduleResult.ok) {
+          appendBotMessage('error', scheduleResult.error || 'Unable to load schedules right now.');
+          return;
+        }
+
+        appendBotMessage('bot', scheduleResult.text);
+        return;
+      }
+
       const result = await sendLangflowMessage(userMessage);
 
       if (!result.ok) {
-        throw new Error(result.error || 'Unable to send message to Langflow.');
+        const isAuthError = String(result.error || '').toLowerCase().includes('authorization');
+        if (isAuthError && isConflictRequest(getLastUserMessage())) {
+          const directConflict = await fetchSchedulesData();
+          if (directConflict.ok) {
+            const conflicts = detectConflicts(directConflict.schedules);
+            appendBotMessage('bot', formatConflictResponse(conflicts));
+            return;
+          }
+        }
+        if (isAuthError && isScheduleListRequest(getLastUserMessage())) {
+          const scheduleResult = await fetchAllSchedules();
+          if (scheduleResult.ok) {
+            appendBotMessage('bot', scheduleResult.text);
+            return;
+          }
+        }
+        appendBotMessage('error', result.error || 'Unable to send message to Langflow.');
+        return;
       }
-      setMessages(prev => [...prev, { type: 'bot', text: result.text }]);
+      appendBotMessage('bot', result.text);
     } catch (err) {
       console.error('Error sending message:', err);
-      setMessages(prev => [...prev, { 
-        type: 'error', 
-        text: `Error: ${err.message}` 
-      }]);
+      appendBotMessage('error', `Error: ${err.message}`);
     } finally {
       setLoading(false);
     }

--- a/src/lib/langflowService.js
+++ b/src/lib/langflowService.js
@@ -1,42 +1,50 @@
 // src/lib/langflowService.js
 
-const FLOW_ID = '2e8b9f3e-10dd-41f6-be28-fd312fc66592';
+import { getToken } from './jwt';
+
+const FLOW_ID = '3fd40497-ce2c-4d71-ac65-208bba9e3839';
 const LANGFLOW_URL = `http://127.0.0.1:7860/api/v1/run/${FLOW_ID}`;
 const API_KEY = 'sk-Fc1IxA_guUpPwB-gR8r77JvV_JB92TBrDj26LYd1DBM';
 
 export async function sendMessage(userMessage) {
-  const token = localStorage.getItem('jwt_token');
+  const token = getToken();
   
   if (!token) {
     return { ok: false, error: 'Auth token missing. Please log in.' };
   }
 
   try {
-    console.log("Sending Tweak:", { "jwt_token": token });
-
     const response = await fetch(LANGFLOW_URL, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'x-api-key': API_KEY,
+        'Authorization': `Bearer ${token}`,
+        authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({
         input_value: userMessage,
         output_type: 'chat',
         input_type: 'chat',
-        tweaks: {
-          "jwt_token": { value: token },
-          "Get All Teachers-jwt_token": { value: token },
-          "Change Schedules-jwt_token": { value: token },
-          "Get Teacher ID-jwt_token": { value: token }
-        },
+        jwt_token: token,
+        authorization: `Bearer ${token}`,
       }),
     });
 
-    const data = await response.json();
+    const textResponse = await response.text();
+    let data = null;
+    try {
+      data = textResponse ? JSON.parse(textResponse) : null;
+    } catch (e) {
+      data = null;
+    }
 
     if (!response.ok) {
-      throw new Error(data?.detail || `API Error: ${response.status}`);
+      const detail = data?.detail || textResponse || `API Error: ${response.status}`;
+      if (String(detail).toLowerCase().includes('missing authorization header')) {
+        return { ok: false, error: 'Your session is not authorized for schedule fetch. Please log out and log in again, then retry.' };
+      }
+      return { ok: false, error: detail };
     }
 
     const text = data?.outputs?.[0]?.outputs?.[0]?.results?.message?.text;
@@ -49,6 +57,6 @@ export async function sendMessage(userMessage) {
 
   } catch (error) {
     console.error("Langflow Request Failed:", error);
-    throw error;
+    return { ok: false, error: error?.message || 'Unable to reach the assistant service.' };
   }
 }

--- a/src/pages/schedules/SchedulesPage.js
+++ b/src/pages/schedules/SchedulesPage.js
@@ -115,12 +115,12 @@ export default function SchedulesPage() {
   const [selectedGrades, setSelectedGrades] = useState([]);
   const [selectedRooms, setSelectedRooms] = useState([]);
   const [availableRooms, setAvailableRooms] = useState([]);
-  const [teacherFilterExpanded, setTeacherFilterExpanded] = useState(true);
-  const [gradeFilterExpanded, setGradeFilterExpanded] = useState(true);
-  const [roomFilterExpanded, setRoomFilterExpanded] = useState(true);
+  const [teacherFilterExpanded, setTeacherFilterExpanded] = useState(false);
+  const [gradeFilterExpanded, setGradeFilterExpanded] = useState(false);
+  const [roomFilterExpanded, setRoomFilterExpanded] = useState(false);
   const [details, setDetails] = useState(initialDetails);
   const [sidebarWidth, setSidebarWidth] = useState(320);
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
   const [isResizing, setIsResizing] = useState(false);
 
   const cleanupDuplicateExceptions = () => {


### PR DESCRIPTION
Add direct schedule and conflict lookup to ChatBot to handle user requests for schedules or conflicts without relying solely on Langflow. Implements scheduleApiBases fallback, JWT-based auth via getToken, schedule formatting, conflict detection and response formatting, and improved bot message deduplication. Update langflowService: switch FLOW_ID, import getToken, attach Authorization headers, robustly parse responses, and return structured error objects instead of throwing. Adjust SchedulesPage defaults to collapse filters and sidebar by default for a more compact initial UI.