### PR TITLE
Add Langflow proxy and use request base URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,8 @@
       },
       "devDependencies": {
         "autoprefixer": "^10.4.21",
+        "express": "^4.18.2",
+        "http-proxy-middleware": "^2.0.3",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.12"
       }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "start": "PORT=4000 react-scripts start",
     "build": "react-scripts build",
+    "start-proxy": "node server/langflow-proxy.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
@@ -49,6 +50,8 @@
   "devDependencies": {
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
-    "tailwindcss": "^4.1.12"
+    "tailwindcss": "^4.1.12",
+    "http-proxy-middleware": "^2.0.3",
+    "express": "^4.18.2"
   }
 }

--- a/server/langflow-proxy.js
+++ b/server/langflow-proxy.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+const app = express();
+const PORT = process.env.LANGFLOW_PROXY_PORT || 4001;
+const TARGET = process.env.REACT_APP_LANGFLOW_BASE_URL || 'http://localhost:7860';
+const API_KEY = process.env.LANGFLOW_API_KEY || process.env.REACT_APP_LANGFLOW_API_KEY || '';
+
+app.use(
+  '/langflow',
+  createProxyMiddleware({
+    target: TARGET,
+    changeOrigin: true,
+    secure: false,
+    pathRewrite: {
+      '^/langflow': '',
+    },
+    onProxyReq: (proxyReq, req, res) => {
+      if (API_KEY) {
+        proxyReq.setHeader('x-api-key', API_KEY);
+      }
+      // forward original authorization header if present
+      const auth = req.headers['authorization'];
+      if (auth) proxyReq.setHeader('authorization', auth);
+    },
+    onProxyRes: (proxyRes, req, res) => {
+      // ensure browser can receive responses during development
+      proxyRes.headers['Access-Control-Allow-Origin'] = req.headers.origin || '*';
+      proxyRes.headers['Access-Control-Allow-Headers'] = 'Authorization,Content-Type,x-api-key';
+      proxyRes.headers['Access-Control-Allow-Methods'] = 'GET,POST,PUT,DELETE,OPTIONS';
+    },
+  })
+);
+
+app.get('/health', (req, res) => res.json({ ok: true, target: TARGET }));
+
+app.listen(PORT, () => {
+  console.log(`Langflow proxy listening on http://localhost:${PORT} -> ${TARGET}`);
+});

--- a/src/constants/apiConstants.js
+++ b/src/constants/apiConstants.js
@@ -7,5 +7,8 @@ const trimTrailingSlash = (value) => String(value || "").replace(/\/+$/, "");
 // REACT_APP_API_BASE takes priority when set; this is only a fallback.
 export const apiUrl = trimTrailingSlash(process.env.REACT_APP_API_BASE || DEFAULT_API_BASE);
 export const langflowBaseUrl = trimTrailingSlash(process.env.REACT_APP_LANGFLOW_BASE_URL || DEFAULT_LANGFLOW_BASE);
+export const langflowRequestBaseUrl = trimTrailingSlash(
+	process.env.REACT_APP_LANGFLOW_REQUEST_BASE_URL || process.env.REACT_APP_LANGFLOW_BASE_URL || DEFAULT_LANGFLOW_BASE
+);
 export const langflowFlowId = process.env.REACT_APP_LANGFLOW_FLOW_ID || DEFAULT_LANGFLOW_FLOW_ID;
 export const langflowApiKey = process.env.REACT_APP_LANGFLOW_API_KEY || "";

--- a/src/lib/langflowService.js
+++ b/src/lib/langflowService.js
@@ -1,9 +1,9 @@
 // src/lib/langflowService.js
 
 import { getToken } from './jwt';
-import { langflowApiKey, langflowBaseUrl, langflowFlowId } from '../constants/apiConstants';
+import { langflowApiKey, langflowFlowId, langflowRequestBaseUrl } from '../constants/apiConstants';
 
-const LANGFLOW_URL = `${langflowBaseUrl}/api/v1/run/${langflowFlowId}`;
+const LANGFLOW_URL = `${langflowRequestBaseUrl}/api/v1/run/${langflowFlowId}`;
 const API_KEY = langflowApiKey;
 
 export async function sendMessage(userMessage) {
@@ -20,14 +20,12 @@ export async function sendMessage(userMessage) {
         'Content-Type': 'application/json',
         ...(API_KEY ? { 'x-api-key': API_KEY } : {}),
         'Authorization': `Bearer ${token}`,
-        authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({
         input_value: userMessage,
         output_type: 'chat',
         input_type: 'chat',
         jwt_token: token,
-        authorization: `Bearer ${token}`,
       }),
     });
 


### PR DESCRIPTION
Add an Express-based development proxy (server/langflow-proxy.js) to forward /langflow requests to a Langflow backend, inject x-api-key, forward Authorization, set CORS response headers, and expose a /health endpoint. Add a start-proxy npm script and add express + http-proxy-middleware to devDependencies. Introduce langflowRequestBaseUrl in apiConstants and update langflowService to use it for run requests, and clean up duplicated authorization fields in the request headers/body.